### PR TITLE
Fix mobile issue with X markers not showing

### DIFF
--- a/queens-game/src/board.ts
+++ b/queens-game/src/board.ts
@@ -123,6 +123,12 @@ export class Board {
       this.handleRightClick(position);
     });
 
+    // Add touch event listeners for mobile devices
+    cell.addEventListener('touchstart', (e) => {
+      e.preventDefault();
+      this.handleTouchStart(e, position);
+    });
+
     return cell;
   }
 
@@ -192,6 +198,29 @@ export class Board {
         this.checkWinCondition();
       } else {
         this.showInvalidPlacement(position, validation.reason);
+      }
+    }
+  }
+
+  /**
+   * Handles touch start events for mobile devices
+   */
+  private handleTouchStart(event: TouchEvent, position: BoardPosition): void {
+    const touch = event.touches[0];
+    const target = document.elementFromPoint(touch.clientX, touch.clientY);
+
+    if (target) {
+      const cell = target.closest('.cell');
+      if (cell) {
+        const row = parseInt(cell.getAttribute('data-row') || '0', 10);
+        const col = parseInt(cell.getAttribute('data-col') || '0', 10);
+        const newPosition = { row, col };
+
+        if (event.touches.length === 1) {
+          this.handleLeftClick(newPosition);
+        } else if (event.touches.length === 2) {
+          this.handleRightClick(newPosition);
+        }
       }
     }
   }

--- a/queens-game/src/board.ts
+++ b/queens-game/src/board.ts
@@ -124,9 +124,43 @@ export class Board {
     });
 
     // Add touch event listeners for mobile devices
+    let touchTimeout: number;
+    let isTouchMoved = false;
+
     cell.addEventListener('touchstart', (e) => {
       e.preventDefault();
+      isTouchMoved = false;
+      
+      // Clear any existing timeout
+      if (touchTimeout) {
+        window.clearTimeout(touchTimeout);
+      }
+
+      // Set a timeout to detect long press
+      touchTimeout = window.setTimeout(() => {
+        if (!isTouchMoved) {
+          this.handleRightClick(position);
+        }
+      }, 500);
+
       this.handleTouchStart(e, position);
+    });
+
+    cell.addEventListener('touchmove', () => {
+      isTouchMoved = true;
+    });
+
+    cell.addEventListener('touchend', () => {
+      if (touchTimeout) {
+        window.clearTimeout(touchTimeout);
+      }
+    });
+
+    cell.addEventListener('touchcancel', () => {
+      if (touchTimeout) {
+        window.clearTimeout(touchTimeout);
+      }
+      isTouchMoved = false;
     });
 
     return cell;
@@ -204,12 +238,12 @@ export class Board {
 
   /**
    * Handles touch start events for mobile devices
+   * Single tap: Place/remove X
+   * Long press: Place/remove queen
    */
   private handleTouchStart(event: TouchEvent, position: BoardPosition): void {
     if (event.touches.length === 1) {
       this.handleLeftClick(position);
-    } else if (event.touches.length === 2) {
-      this.handleRightClick(position);
     }
   }
 

--- a/queens-game/src/board.ts
+++ b/queens-game/src/board.ts
@@ -205,7 +205,7 @@ export class Board {
   /**
    * Handles touch start events for mobile devices
    */
-  private handleTouchStart(event: TouchEvent, position: BoardPosition): void {
+  private handleTouchStart(event: TouchEvent): void {
     const touch = event.touches[0];
     const target = document.elementFromPoint(touch.clientX, touch.clientY);
 

--- a/queens-game/src/board.ts
+++ b/queens-game/src/board.ts
@@ -136,9 +136,13 @@ export class Board {
         window.clearTimeout(touchTimeout);
       }
 
+      // Add long-press class after a short delay
+      cell.classList.add('long-press');
+
       // Set a timeout to detect long press
       touchTimeout = window.setTimeout(() => {
         if (!isTouchMoved) {
+          cell.classList.remove('long-press');
           this.handleRightClick(position);
         }
       }, 500);
@@ -154,12 +158,14 @@ export class Board {
       if (touchTimeout) {
         window.clearTimeout(touchTimeout);
       }
+      cell.classList.remove('long-press');
     });
 
     cell.addEventListener('touchcancel', () => {
       if (touchTimeout) {
         window.clearTimeout(touchTimeout);
       }
+      cell.classList.remove('long-press');
       isTouchMoved = false;
     });
 

--- a/queens-game/src/board.ts
+++ b/queens-game/src/board.ts
@@ -205,23 +205,11 @@ export class Board {
   /**
    * Handles touch start events for mobile devices
    */
-  private handleTouchStart(event: TouchEvent): void {
-    const touch = event.touches[0];
-    const target = document.elementFromPoint(touch.clientX, touch.clientY);
-
-    if (target) {
-      const cell = target.closest('.cell');
-      if (cell) {
-        const row = parseInt(cell.getAttribute('data-row') || '0', 10);
-        const col = parseInt(cell.getAttribute('data-col') || '0', 10);
-        const newPosition = { row, col };
-
-        if (event.touches.length === 1) {
-          this.handleLeftClick(newPosition);
-        } else if (event.touches.length === 2) {
-          this.handleRightClick(newPosition);
-        }
-      }
+  private handleTouchStart(event: TouchEvent, position: BoardPosition): void {
+    if (event.touches.length === 1) {
+      this.handleLeftClick(position);
+    } else if (event.touches.length === 2) {
+      this.handleRightClick(position);
     }
   }
 

--- a/queens-game/src/style.css
+++ b/queens-game/src/style.css
@@ -69,7 +69,29 @@ h1 {
   font-size: 2rem;
   transition: all 0.3s ease;
   position: relative;
-  touch-action: manipulation; /* Ensure touch feedback on mobile devices */
+  touch-action: manipulation;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  min-width: 44px; /* Minimum tap target size */
+  min-height: 44px;
+}
+
+@media (hover: none) {
+  .cell:active {
+    background-color: rgba(52, 152, 219, 0.2);
+  }
+
+  .cell.long-press {
+    background-color: rgba(52, 152, 219, 0.4);
+    animation: pulse 0.5s infinite;
+  }
+}
+
+@keyframes pulse {
+  0% { transform: scale(1); }
+  50% { transform: scale(0.95); }
+  100% { transform: scale(1); }
 }
 
 .cell:hover {
@@ -125,6 +147,22 @@ h1 {
   z-index: 100;
   pointer-events: none;
   animation: fadeIn 0.2s ease-out;
+  max-width: 200px;
+  text-align: center;
+}
+
+@media (max-width: 480px) {
+  .tooltip {
+    font-size: 0.75rem;
+    padding: 0.35rem;
+    max-width: 150px;
+    white-space: normal;
+  }
+
+  :root {
+    --cell-size: 50px;
+    --queen-size: 2.2rem;
+  }
 }
 
 /* Modal styles */

--- a/queens-game/src/style.css
+++ b/queens-game/src/style.css
@@ -25,6 +25,7 @@ body {
   align-items: center;
   min-height: 100vh;
   background-color: #ecf0f1;
+  padding: 1rem; /* Ensure responsiveness on mobile devices */
 }
 
 .game-container {
@@ -33,6 +34,8 @@ body {
   align-items: center;
   gap: 2rem;
   padding: 2rem;
+  max-width: 100%; /* Ensure responsiveness on mobile devices */
+  overflow-x: auto; /* Ensure responsiveness on mobile devices */
 }
 
 .header {
@@ -66,6 +69,7 @@ h1 {
   font-size: 2rem;
   transition: all 0.3s ease;
   position: relative;
+  touch-action: manipulation; /* Ensure touch feedback on mobile devices */
 }
 
 .cell:hover {

--- a/queens-game/src/tutorial.ts
+++ b/queens-game/src/tutorial.ts
@@ -30,7 +30,7 @@ export class Tutorial {
             board: Array(5).fill(null).map((_) =>
                 Array(5).fill(null).map(() => ({}))
             ),
-            text: `Controls: Right-click to place/remove ${Tutorial.QUEEN}s, left-click to mark/unmark squares with ${Tutorial.X}. Let's begin!`,
+            text: `Controls:\n• Mouse: Right-click to place/remove ${Tutorial.QUEEN}s, left-click to mark/unmark squares with ${Tutorial.X}\n• Mobile: Tap to mark/unmark ${Tutorial.X}s (manual mode), long-press to place/remove ${Tutorial.QUEEN}s\n• Auto-X mode: When enabled, ${Tutorial.X}s are automatically placed on squares attacked by queens\n\nLet's begin!`,
             buttonText: "Got it"
         },
         {


### PR DESCRIPTION
Fixes #1

Add touch event support for mobile devices to display X markers after placing a queen.

* **`queens-game/src/board.ts`**
  - Add touch event listeners in `initializeBoard` method to handle touch interactions for placing X markers and queens.
  - Add `handleTouchStart` method to process touch start events and determine the appropriate action (left or right click).

* **`queens-game/src/style.css`**
  - Add touch feedback styles for `.cell` class to ensure touch responsiveness.
  - Update `body` and `.game-container` styles to ensure responsiveness on mobile devices.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/w3bdesign/queens-javascript/pull/2?shareId=e5f08c29-3219-4b7b-af02-586efeb4fa90).